### PR TITLE
reroll if `Rand::rand` gives a zero seed

### DIFF
--- a/src/xoroshiro128.rs
+++ b/src/xoroshiro128.rs
@@ -96,8 +96,10 @@ impl<'a> SeedableRng<&'a [u64]> for Xoroshiro128 {
 impl Rand for Xoroshiro128 {
     fn rand<R: Rng>(other: &mut R) -> Xoroshiro128 {
         let mut key: [u64; STATE_SIZE] = [0; STATE_SIZE];
-        for word in &mut key {
-            *word = other.gen();
+        while key.iter().all(|&x| x == 0) {
+            for word in &mut key {
+                *word = other.gen();
+            }
         }
         SeedableRng::from_seed(&key[..])
     }

--- a/src/xoroshiro128.rs
+++ b/src/xoroshiro128.rs
@@ -97,9 +97,7 @@ impl Rand for Xoroshiro128 {
     fn rand<R: Rng>(other: &mut R) -> Xoroshiro128 {
         let mut key: [u64; STATE_SIZE] = [0; STATE_SIZE];
         while key.iter().all(|&x| x == 0) {
-            for word in &mut key {
-                *word = other.gen();
-            }
+            key = other.gen();
         }
         SeedableRng::from_seed(&key[..])
     }


### PR DESCRIPTION
Currently there's a chance a seed of all zeros could be produced by the other RNG.  A zero seed will never produce anything but zero because of the way the RNG works.

"The state must be seeded so that it is not everywhere zero."
--<http://xoroshiro.di.unimi.it/xoroshiro128plus.c>